### PR TITLE
Fix version string parsing

### DIFF
--- a/lib/decode.ml
+++ b/lib/decode.ml
@@ -40,16 +40,20 @@ let get_version buf =
     else if line_len < 9 then
       error "Version line is too short"
     else
-      let tokens = Str.split_delim (Str.regexp "-") line in
+      (* Strip the comments *)
+      let version_line = try
+          String.sub line 0 (String.index line ' ')
+        with Not_found -> line
+      in
+      let tokens = Str.split_delim (Str.regexp "-") version_line in
       if List.length tokens <> 3 then
         error "Can't parse version line"
       else
         let version = List.nth tokens 1 in
-        let peer_version = List.nth tokens 2 in
         if version <> "2.0" then
           error ("Bad version " ^ version)
         else
-          ok (Some peer_version)
+          ok (Some version_line)
   in
   (* Scan all lines until an error or SSH version is found *)
   let rec scan buf =

--- a/test/test.ml
+++ b/test/test.ml
@@ -88,6 +88,7 @@ let t_banner () =
     "SSH-2.0-OpenSSH_6.9\r\n";
     "Some crap before\r\nSSH-2.0-OpenSSH_6.9\r\n";
     "SSH-2.0-OpenSSH_6.9\r\nSomeCrap After\r\n";
+    "SSH-2.0-OpenSSH_7.4p1 Debian-6\r\n";
   ]
   in
   List.iter (fun s ->
@@ -281,9 +282,9 @@ let t_version () =
   | Ok (t, msg) ->
     match get_some msg with
     | Ssh.Ssh_msg_version v ->
-      assert (v = "OpenSSH_6.9");
+      assert (v = "SSH-2.0-OpenSSH_6.9");
       let t, _ =  get_ok_s @@ Server.handle_msg t (Ssh.Ssh_msg_version v) in
-      assert (t.Server.client_version = (Some "OpenSSH_6.9"))
+      assert (t.Server.client_version = (Some "SSH-2.0-OpenSSH_6.9"))
     | _ -> failwith "Expected Ssh_version"
 
 let t_crypto () =


### PR DESCRIPTION
Version string is everything up to the CR LF, including "SSH-" and the
comments.

Includes a test.