### PR TITLE
First kex packet follows

### DIFF
--- a/lib/kex.ml
+++ b/lib/kex.ml
@@ -84,6 +84,23 @@ type negotiation = {
   compression_alg_stoc : compression_alg;
 }
 
+let guessed_right ~s ~c =
+  let compare_hd a b =
+    match (a, b) with
+    | [], [] -> true
+    | [], _  -> false
+    | _, []  -> false
+    | x :: _, y :: _ -> x = y
+  in
+  compare_hd s.kex_algs c.kex_algs &&
+  compare_hd s.server_host_key_algs c.server_host_key_algs &&
+  compare_hd s.encryption_algs_ctos c.encryption_algs_ctos &&
+  compare_hd s.encryption_algs_stoc c.encryption_algs_stoc &&
+  compare_hd s.mac_algs_ctos c.mac_algs_ctos &&
+  compare_hd s.mac_algs_stoc c.mac_algs_stoc &&
+  compare_hd s.compression_algs_ctos c.compression_algs_ctos &&
+  compare_hd s.compression_algs_stoc c.compression_algs_stoc
+
 let negotiate ~s ~c =
   let pick_common f ~s ~c e =
     try

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -41,6 +41,7 @@ type t = {
   expect         : Ssh.message_id option; (* Which messages are expected, None if any *)
   auth_state     : (string * string) option; (* username * service in progress *)
   user_db        : user list;             (* username database *)
+  ignore_next_packet : bool;              (* Ignore the next packet from the wire *)
 }
 
 let guard_msg t msg =
@@ -73,7 +74,8 @@ let make host_key user_db =
             input_buffer = Cstruct.create 0;
             expect = Some SSH_MSG_VERSION;
             auth_state = None;
-            user_db }
+            user_db;
+            ignore_next_packet = false }
   in
   t, [ banner_msg; kex_msg ]
 
@@ -114,9 +116,13 @@ let pop_msg2 t buf =
     Packet.decrypt t.keys_ctos buf >>= function
     | None -> ok (t, None)
     | Some (pkt, buf, keys_ctos) ->
-      Packet.to_msg pkt >>= fun msg ->
-      let t = { t with keys_ctos } in
-      ok (of_buf t buf, Some msg)
+      if t.ignore_next_packet then
+        let t = {t with ignore_next_packet = false } in
+          ok (t, None)
+      else
+        Packet.to_msg pkt >>= fun msg ->
+        let t = { t with keys_ctos } in
+        ok (of_buf t buf, Some msg)
   in
   match t.client_version with
   | None -> version t buf

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -477,10 +477,6 @@ let put_message msg buf =
     | Ssh_msg_version version ->  (* Mocked up version message *)
       put_raw (Cstruct.of_string (version ^ "\r\n")) buf
 
-(* Useful for testing *)
-let buf_of_message m =
-  put_message m (Dbuf.create ()) |> Dbuf.to_cstruct
-
 (* XXX Maybe move this to Packet *)
 let get_payload buf =
   let open Ssh in

--- a/test/test.ml
+++ b/test/test.ml
@@ -344,6 +344,31 @@ let t_signature () =
     Cstruct.set_uint8 signed off evilbyte;
   done
 
+let t_ignore_next_packet () =
+  (*
+   * Case 5: Make sure next packet will be ignored if ignore_next_packet
+   * is true
+   *)
+
+  let t, _ = Server.make (Hostkey.Rsa_priv (Nocrypto.Rsa.generate 2048)) in
+  let t = Server.{
+     t with ignore_next_packet = true; client_version = Some ("SSH-2.0-client")
+  } in
+  let message = Ssh.Ssh_msg_debug(true, "woop", "Look at me") in
+  let buf = encrypt_plain (message) in
+  let t, msg = get_ok (Server.pop_msg2 t buf) in
+  assert (t.Server.ignore_next_packet = false);
+  assert (msg = None);
+  let buf = encrypt_plain (message) in
+  let t, msg = get_ok (Server.pop_msg2 t buf) in
+  assert (t.Server.ignore_next_packet = false);
+  assert (msg = Some(message))
+
+let t_set_ignore_next_packet () =
+  let t, _ = Server.make (Hostkey.Rsa_priv (Nocrypto.Rsa.generate 2048)) in
+  let t = Server.{t with client_version = Some ("SSH-2.0-client")} in
+
+
 let run_test test =
   let f = fst test in
   let name = snd test in
@@ -364,6 +389,7 @@ let all_tests = [
   (t_crypto, "encrypt/decrypt");
   (t_openssh_pub, "OpenSSH public key format");
   (t_signature, "signatures");
+  (t_ignore_next_packet, "ignore next packet");
 ]
 
 let _ =

--- a/test/unix_server.ml
+++ b/test/unix_server.ml
@@ -72,7 +72,7 @@ let user_db =
   Unix.close fd;
   let awa = Server.{ name = "awa"; password = None; keys = [ key ] } in
   [ foo; awa ]
-  
+
 let () =
   Nocrypto.Rng.reseed (Cstruct.of_string "180586");
   let server_port = 18022 in


### PR DESCRIPTION
The RFC 4253 states in section 7 that first_kex_packet_follows:

>   If the other party's guess was wrong, and this field was TRUE,
>   the next packet MUST be silently ignored,

So I add a option to ignore the next packet and set the option
as described in the RFC