### PR TITLE
Serialize and De-serialize further messages.

### DIFF
--- a/lib/ssh.ml
+++ b/lib/ssh.ml
@@ -111,6 +111,18 @@ type mpint = Nocrypto.Numeric.Z.t
 
 let sexp_of_mpint mpint = sexp_of_string (Z.to_string mpint)
 
+type global_request =
+  | Tcpip_forward of (string * int32)
+  | Cancel_tcpip_forward of (string * int32)
+
+let sexp_of_global_request = function
+  | Tcpip_forward (address, port) ->
+    sexp_of_string
+      (sprintf "tcpip-forward bind-to=%s port=%ld" address port)
+  | Cancel_tcpip_forward (address, port) ->
+    sexp_of_string
+      (sprintf "cancel-tcpip-forward bind-to=%s port=%ld" address port)
+
 type auth_method =
   | Pubkey of (string * Hostkey.pub * Cstruct.t option) (* TODO remove key_alg *)
   | Password of (string * string option)
@@ -163,18 +175,18 @@ type message =
   | Ssh_msg_newkeys
   | Ssh_msg_kexdh_reply of (Hostkey.pub * mpint * Cstruct.t)
   | Ssh_msg_kexdh_init of mpint
-  | Ssh_msg_userauth_request of (string * string * auth_method)
-  | Ssh_msg_userauth_failure of (string list * bool)
+  | Ssh_msg_userauth_request of string * string * auth_method
+  | Ssh_msg_userauth_failure of string list * bool
   | Ssh_msg_userauth_success
-  | Ssh_msg_userauth_banner of (string * string)
+  | Ssh_msg_userauth_banner of string * string
   | Ssh_msg_userauth_pk_ok of Hostkey.pub
-  | Ssh_msg_global_request
-  | Ssh_msg_request_success
+  | Ssh_msg_global_request of string * bool * global_request
+  | Ssh_msg_request_success of Cstruct.t option
   | Ssh_msg_request_failure
   | Ssh_msg_channel_open
   | Ssh_msg_channel_open_confirmation
   | Ssh_msg_channel_open_failure
-  | Ssh_msg_channel_window_adjust of (int32 * int32)
+  | Ssh_msg_channel_window_adjust of int32 * int32
   | Ssh_msg_channel_data
   | Ssh_msg_channel_extended_data
   | Ssh_msg_channel_eof of int32
@@ -204,8 +216,8 @@ let message_to_id = function
   | Ssh_msg_userauth_success           -> SSH_MSG_USERAUTH_SUCCESS
   | Ssh_msg_userauth_banner _          -> SSH_MSG_USERAUTH_BANNER
   | Ssh_msg_userauth_pk_ok _           -> SSH_MSG_USERAUTH_PK_OK
-  | Ssh_msg_global_request             -> SSH_MSG_GLOBAL_REQUEST
-  | Ssh_msg_request_success            -> SSH_MSG_REQUEST_SUCCESS
+  | Ssh_msg_global_request _           -> SSH_MSG_GLOBAL_REQUEST
+  | Ssh_msg_request_success _          -> SSH_MSG_REQUEST_SUCCESS
   | Ssh_msg_request_failure            -> SSH_MSG_REQUEST_FAILURE
   | Ssh_msg_channel_open               -> SSH_MSG_CHANNEL_OPEN
   | Ssh_msg_channel_open_confirmation  -> SSH_MSG_CHANNEL_OPEN_CONFIRMATION

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -314,7 +314,7 @@ let get_message buf =
        get_cstring buf >>= fun (hostsig, buf) ->
        ok (Hostbased (key_alg, key_blob, hostname, hostuser, hostsig), buf)
      | "none" -> ok (Authnone, buf)
-     | auth_metod -> error ("Unknown method " ^ auth_method))
+     | _ -> error ("Unknown method " ^ auth_method))
     >>= fun (auth_method, buf) ->
     ok (Ssh_msg_userauth_request (user, service, auth_method))
   | SSH_MSG_USERAUTH_FAILURE ->
@@ -330,8 +330,24 @@ let get_message buf =
     get_string buf >>= fun (s1, buf) ->
     get_string buf >>= fun (s2, buf) ->
     ok (Ssh_msg_userauth_banner (s1, s2))
-  | SSH_MSG_GLOBAL_REQUEST -> unimplemented ()
-  | SSH_MSG_REQUEST_SUCCESS -> unimplemented ()
+  | SSH_MSG_GLOBAL_REQUEST ->
+    get_string buf >>= fun (request, buf) ->
+    get_bool buf >>= fun (want_reply, buf) ->
+    (match request with
+     | "tcpip-forward" ->
+       get_string buf >>= fun (address, buf) ->
+       get_uint32 buf >>= fun (port, buf) ->
+       ok (Tcpip_forward (address, port), buf)
+     | "cancel-tcpip-forward" ->
+       get_string buf >>= fun (address, buf) ->
+       get_uint32 buf >>= fun (port, buf) ->
+       ok (Cancel_tcpip_forward (address, port), buf)
+     | _ -> error ("Unknown request " ^ request))
+    >>= fun (global_request, buf) ->
+    ok (Ssh_msg_global_request (request, want_reply, global_request))
+  | SSH_MSG_REQUEST_SUCCESS ->
+    let req_data = if Cstruct.len buf > 0 then Some buf else None in
+    ok (Ssh_msg_request_success req_data)
   | SSH_MSG_REQUEST_FAILURE -> ok Ssh_msg_request_failure
   | SSH_MSG_CHANNEL_OPEN -> unimplemented ()
   | SSH_MSG_CHANNEL_OPEN_CONFIRMATION -> unimplemented ()
@@ -447,8 +463,23 @@ let put_message msg buf =
       put_id SSH_MSG_USERAUTH_PK_OK buf |>
       put_string (Hostkey.sshname pubkey) |>
       put_pubkey pubkey
-    | Ssh_msg_global_request -> unimplemented ()
-    | Ssh_msg_request_success -> unimplemented ()
+    | Ssh_msg_global_request (request, want_reply, global_request) ->
+      let buf = put_id SSH_MSG_GLOBAL_REQUEST buf |>
+                put_string request |>
+                put_bool want_reply
+      in
+      (match global_request with
+       | Tcpip_forward (address, port) ->
+         put_string address buf |>
+                   put_uint32 port
+       | Cancel_tcpip_forward (address, port) ->
+         put_string address buf |>
+         put_uint32 port)
+    | Ssh_msg_request_success (req_data) ->
+      let buf = put_id SSH_MSG_REQUEST_SUCCESS buf in
+      (match req_data with
+       | Some data -> put_cstring data buf
+       | None -> buf)
     | Ssh_msg_request_failure ->
       put_id SSH_MSG_REQUEST_FAILURE buf
     | Ssh_msg_channel_open -> unimplemented ()

--- a/test/test.ml
+++ b/test/test.ml
@@ -182,9 +182,11 @@ let t_parsing () =
       Ssh_msg_userauth_success;
       Ssh_msg_userauth_banner ("Fora", "Temer");
       Ssh_msg_userauth_pk_ok pub_rsa;
-      (* Ssh_msg_global_request; *)
-      (* Ssh_msg_request_success; *)
-      (* Ssh_msg_request_failure; *)
+      Ssh_msg_global_request
+        ("tcpip-forward", true,
+        Tcpip_forward ("127.0.0.1", Int32.of_int 443));
+      Ssh_msg_request_success (None);
+      Ssh_msg_request_failure;
       (* Ssh_msg_channel_open; *)
       (* Ssh_msg_channel_open_confirmation; *)
       (* Ssh_msg_channel_open_failure; *)


### PR DESCRIPTION
For RFC 4254 there is need for more messages to be
serilized and de-serialized:

SSH_MSG_GLOBAL_REQUEST
SSH_MSG_REQUEST_SUCCESS
  which needs some special handling in de-serialization since it is
  not clear wether parameters for that request were send or not.
  The caller needs to handle that
SSH_MSG_REQUEST_FAILURE