### PR TITLE
more kex

### DIFF
--- a/lib/client.ml
+++ b/lib/client.ml
@@ -120,7 +120,7 @@ let handle_kexinit t c_v ckex s_v skex =
 let handle_kexdh_reply t now v_c ckex v_s skex neg secret my_pub k_s theirs signed =
   Kex.Dh.shared secret theirs >>= fun shared ->
   let h =
-    Kex.Dh.compute_hash
+    Kex.Dh.compute_hash neg
       ~v_c ~v_s ~i_c:(Wire.blob_of_kexinit ckex) ~i_s:skex.Ssh.rawkex
       ~k_s ~e:my_pub ~f:theirs ~k:shared
   in

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -312,7 +312,7 @@ let input_msg t msg now =
     guard_some t.client_kexinit "No client kex" >>= fun c ->
     Kex.(Dh.generate neg.kex_alg e) >>= fun (f, k) ->
     let pub_host_key = Hostkey.pub_of_priv t.host_key in
-    let h = Kex.Dh.compute_hash
+    let h = Kex.Dh.compute_hash neg
         ~v_c:client_version
         ~v_s:t.server_version
         ~i_c:c.rawkex

--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -767,25 +767,26 @@ let get_version buf =
   (* Extract SSH version from line *)
   let processline line =
     let line_len = String.length line in
-    if line_len < 4 || String.sub line 0 4 <> "SSH-" then
+    if line_len < 4 || not String.(equal (sub line 0 4) "SSH-") then
       ok None
     else if line_len < 9 then
       error "Version line is too short"
     else
       (* Strip the comments *)
-      let version_line = try
+      let version_line =
+        try
           String.sub line 0 (String.index line ' ')
         with Not_found -> line
       in
       let tokens = String.split_on_char '-' version_line in
-      if List.length tokens <> 3 then
-        error "Can't parse version line"
+      if List.length tokens < 3 then
+        error ("Can't parse version line: " ^ version_line)
       else
         let version = List.nth tokens 1 in
-        if version <> "2.0" then
-          error ("Bad version " ^ version)
-        else
+        if String.equal version "2.0" then
           ok (Some line)
+        else
+          error ("Bad version " ^ version)
   in
   (* Scan all lines until an error or SSH version is found *)
   let rec scan buf =

--- a/test/awa_lwt_server.ml
+++ b/test/awa_lwt_server.ml
@@ -20,7 +20,7 @@ let user_db =
   (* User foo auths by passoword *)
   let foo = Awa.Auth.make_user "foo" ~password:"bar" [] in
   (* User awa auths by pubkey *)
-  let fd = Unix.(openfile "test/awa_test_rsa.pub" [O_RDONLY] 0) in
+  let fd = Unix.(openfile "test/data/awa_test_rsa.pub" [O_RDONLY] 0) in
   let file_buf = Unix_cstruct.of_fd fd in
   let key = Rresult.R.get_ok (Awa.Wire.pubkey_of_openssh file_buf) in
   Unix.close fd;

--- a/test/test.ml
+++ b/test/test.ml
@@ -85,7 +85,11 @@ let t_banner () =
     "\r\n\r\nSSH-2.0-foobar lalal\r\n";
     "SSH-2.0-foobar lalal lololo\r\n";
     "SSH-2.0-OpenSSH_6.9\r\n";
+    "SSH-2.0-Open-SSH_6.9\r\n";
+    "SSH-2.0-babeld-72deb3a2\r\n";
     "Some crap before\r\nSSH-2.0-OpenSSH_6.9\r\n";
+    "Some crap before\r\nSSH-2.0-Open-SSH_6.9\r\n";
+    "\r\nSSH-2.0-Open-SSH_6.9\r\nSom crap after";
     "SSH-2.0-OpenSSH_6.9\r\nSomeCrap After\r\n";
     "SSH-2.0-OpenSSH_7.4p1 Debian-6-lala-lolo\r\n";
   ]
@@ -100,15 +104,12 @@ let t_banner () =
   let bad_strings = [
     "SSH-2.0\r\n";
     "SSH-1.0-foobar lalal lololo\r\n";
-    "SSH-2.0-Open-SSH_6.9\r\n";
-    "Some crap before\r\nSSH-2.0-Open-SSH_6.9\r\n";
-    "\r\nSSH-2.0-Open-SSH_6.9\r\nSom crap after";
     "SSH-2.0-partiallineomg";
   ]
   in
   List.iter (fun s ->
       match Wire.get_version (Cstruct.of_string s) with
-      | Ok (Some _, _) -> failwith "expected none or error"
+      | Ok (Some _, _) -> failwith ("expected none or error: " ^ s)
       | Ok (None, _) -> ()
       | Error _ -> ())
     bad_strings;


### PR DESCRIPTION
the original setup supported oakley2 and oakley14 with sha1. this isn't en vogue anymore, so I added support for sha256 for oakley14.

turns out, modern is to use RFC4419 (where the server dictates the DH group, the client says "minimal, n, and maximum" size of the modulus). this is a slightly more complex protocol. downside is as well they reuse ssh message ids, thus 30-49 can't be parsed directly, but need context-sensitive parsers.

this PR adds 4419 support for the ssh client (not for the server though). this allows awa to talk with github again.