### PR TITLE
awa: explicitly depend on astring

### DIFF
--- a/awa.opam
+++ b/awa.opam
@@ -16,6 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.0"}
+  "astring"
   "ppx_sexp_conv"
   "ppx_cstruct"
   "mirage-crypto" {>= "0.8.1"}

--- a/lib/dune
+++ b/lib/dune
@@ -2,4 +2,4 @@
  (name awa)
  (public_name awa)
  (preprocess (pps ppx_cstruct ppx_sexp_conv))
- (libraries cstruct cstruct-sexp mirage-crypto mirage-crypto-rng mirage-crypto-pk zarith x509 mtime sexplib rresult logs base64 mirage-crypto-ec))
+ (libraries astring cstruct cstruct-sexp mirage-crypto mirage-crypto-rng mirage-crypto-pk zarith x509 mtime sexplib rresult logs base64 mirage-crypto-ec))


### PR DESCRIPTION
Until now it was working because it got it transitively from `domain-name`.
Seen on https://github.com/ocaml/opam-repository/pull/19881