### PR TITLE
Fix how we parse MSG_KEX_{0,1,2,3,4} and MSG_USERAUTH_{1,2}

### DIFF
--- a/lib/wire.ml
+++ b/lib/wire.ml
@@ -413,7 +413,7 @@ let get_message buf =
   | MSG_NEWKEYS ->
     Ok Msg_newkeys
   | MSG_KEX_0 | MSG_KEX_1 | MSG_KEX_2 | MSG_KEX_3 | MSG_KEX_4 ->
-    Ok (Msg_kex (msgid, buf))
+    Ok (Msg_kex (msgid, String.sub buf off (String.length buf - off)))
   | MSG_USERAUTH_REQUEST ->
     let* user, off = get_string buf off in
     let* service, off = get_string buf off in
@@ -454,8 +454,12 @@ let get_message buf =
     let* psucc, _ = get_bool buf off in
     Ok (Msg_userauth_failure (nl, psucc))
   | MSG_USERAUTH_SUCCESS -> Ok Msg_userauth_success
-  | MSG_USERAUTH_1 -> Ok (Msg_userauth_1 buf)
-  | MSG_USERAUTH_2 -> Ok (Msg_userauth_2 buf)
+  | MSG_USERAUTH_1 ->
+    let buf = String.sub buf off (String.length buf - off) in
+    Ok (Msg_userauth_1 buf)
+  | MSG_USERAUTH_2 ->
+    let buf = String.sub buf off (String.length buf - off) in
+    Ok (Msg_userauth_2 buf)
   | MSG_USERAUTH_BANNER ->
     let* s1, off = get_string buf off in
     let* s2, _ = get_string buf off in

--- a/test/test.ml
+++ b/test/test.ml
@@ -252,11 +252,48 @@ let t_parsing () =
       Msg_channel_request (long, false, Exit_status long);
       Msg_channel_request (long, false, Exit_signal ("a", false, "b", "c"));
       (* It's illegal to serialize Raw_data for now *)
-      (* Msg_channel_request (long, false, Raw_data (Cstruct.of_string "Hegel")); *)
+      (* Msg_channel_request (long, false, Raw_data "Hegel"); *)
       Msg_channel_success long;
-      Msg_channel_failure long; ]
+      Msg_channel_failure long;
+    ]
   in
   List.iter (fun m -> id m) l;
+  test_ok
+
+let t_parsing_kex_userauth () =
+  let buf id data =
+    let b = Buffer.create 10 in
+    Wire.put_message_id b id;
+    Buffer.add_string b data;
+    Buffer.contents b
+  in
+  let check = function
+    | Ssh.Msg_kex (id, data) ->
+      let buf = buf id data in
+      (match Wire.get_message buf with
+       | Ok (Msg_kex (id', data')) when String.equal data data' && id = id' -> ()
+       | _ -> invalid_arg "failed")
+    | Msg_userauth_1 data ->
+      let buf = buf MSG_USERAUTH_1 data in
+      (match Wire.get_message buf with
+       | Ok (Msg_userauth_1 data') when String.equal data data' -> ()
+       | _ -> invalid_arg "failed")
+    | Msg_userauth_2 data ->
+      let buf = buf MSG_USERAUTH_2 data in
+      (match Wire.get_message buf with
+       | Ok (Msg_userauth_2 data') when String.equal data data' -> ()
+       | _ -> invalid_arg "failed")
+    | _ -> assert false
+  in
+  List.iter check [
+    Msg_kex (MSG_KEX_0, "abc");
+    Msg_kex (MSG_KEX_1, "");
+    Msg_kex (MSG_KEX_2, "foobar");
+    Msg_kex (MSG_KEX_3, "bar");
+    Msg_kex (MSG_KEX_4, "blabla");
+    Msg_userauth_1 "I'm a user";
+    Msg_userauth_2 "Really";
+  ];
   test_ok
 
 let string_of_file file =
@@ -603,6 +640,7 @@ let run_test test =
 
 let all_tests = [
   (t_parsing, "basic parsing");
+  (t_parsing_kex_userauth, "basic parsing of kex and userauth");
   (t_banner, "version banner");
   (t_key_exchange, "key exchange");
   (t_namelist, "namelist conversions");


### PR DESCRIPTION
During #85, I spotted a bug (when I started to experiment with `mnet`). Previously, the code was:
```ocaml
let get_message buf =
  let open Ssh in
  let msgbuf = buf in
  let* msgid, buf = get_message_id buf in
  ...
  | MSG_KEX_0 | MSG_KEX_1 | MSG_KEX_2 | MSG_KEX_3 | MSG_KEX_4 ->
    Ok (Msg_kex (msgid, buf))
```

So `buf` is `msgbuf` without the `msgid` (a `Cstruct.sub`). `buf` on the current state of `wire.ml` is the full payload, we must truncate the `msgid`.